### PR TITLE
Removed option to set WC Cart tab to Top

### DIFF
--- a/inc/constants.php
+++ b/inc/constants.php
@@ -162,7 +162,6 @@ interface BUILDR_OPTIONS {
             WOO_SLIDE_CART_TOGGLE                   = 'cart_drawer_toggle',
             WOO_SLIDE_CART_TAB_COLOR                = 'cart_drawer_tab_color',
             WOO_SLIDE_CART_TAB_ICON                 = 'cart_drawer_tab_icon',
-            WOO_SLIDE_CART_TAB_POSITION             = 'cart_drawer_tab_location',
             
             HOMEPAGE_SHOW_CONTENT                   = 'homepage_show_content_toggle',
             SINGLE_POST_SHOW_NAVIGATION             = 'show_single_post_navigation',
@@ -334,7 +333,6 @@ interface BUILDR_DEFAULTS {
             WOO_SLIDE_CART_TOGGLE                   = true,
             WOO_SLIDE_CART_TAB_COLOR                = '#000000',
             WOO_SLIDE_CART_TAB_ICON                 = 'fa-shopping-cart',
-            WOO_SLIDE_CART_TAB_POSITION             = 'bottom',
 
             HOMEPAGE_SHOW_CONTENT                   = true,
             SINGLE_POST_SHOW_NAVIGATION             = true,

--- a/inc/functions-css.php
+++ b/inc/functions-css.php
@@ -890,27 +890,6 @@ function buildr_wp_head_styles() { ?>
         
         <?php endif; ?>
             
-        /* ---------------------------------------------------------------------
-         * Slide-In Cart
-         * ------------------------------------------------------------------ */
-            
-        <?php if ( get_theme_mod( BUILDR_OPTIONS::WOO_SLIDE_CART_TAB_POSITION, BUILDR_DEFAULTS::WOO_SLIDE_CART_TAB_POSITION ) == 'top' ) : ?>
-        
-            @media (min-width:992px) {
-        
-                div#cart-panel-trigger {
-                    top: <?php echo intval( get_theme_mod( BUILDR_OPTIONS::NAVBAR_INITIAL_HEIGHT, BUILDR_DEFAULTS::NAVBAR_INITIAL_HEIGHT ) + 12 ); ?>px;    
-                }
-
-                div#cart-panel-trigger.sticky-header {
-                    top: <?php echo intval( get_theme_mod( BUILDR_OPTIONS::NAVBAR_STICKY_HEIGHT, BUILDR_DEFAULTS::NAVBAR_STICKY_HEIGHT ) + 12 ); ?>px;
-                }
-            
-            }
-        
-        <?php endif; ?>
-            
-            
     </style>
 
 <?php


### PR DESCRIPTION
For UI and UX reasons, the button to open the slide-in cart panel should be limited to the bottom.